### PR TITLE
Add ws-aggregator and bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 # Only update version on publishing to Maven Central
-version=1.7.0
+version=1.7.1

--- a/transport-nethernet/src/main/java/dev/kastle/netty/channel/nethernet/signaling/AbstractNetherNetXboxSignaling.java
+++ b/transport-nethernet/src/main/java/dev/kastle/netty/channel/nethernet/signaling/AbstractNetherNetXboxSignaling.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -114,6 +115,7 @@ public abstract class AbstractNetherNetXboxSignaling extends SimpleChannelInboun
                      p.addLast(sslCtx.newHandler(ch.alloc(), uri.getHost(), 443));
                      p.addLast(new HttpClientCodec(), new HttpObjectAggregator(8192));
                      p.addLast("ws-handshake", new WebSocketClientProtocolHandler(handshaker));
+                     p.addLast("ws-aggregator", new WebSocketFrameAggregator(16 * 1024)); // Allow 16KB aggregations
                      p.addLast("handler", AbstractNetherNetXboxSignaling.this);
                  }
              });


### PR DESCRIPTION
Fixes issues with 26.30 by adding a WebSocketFrameAggregator to the Xbox signaling pipeline, reassembling fragmented WebSocket frames before JSON parsing

Allows upto 16KB aggregation, in testing the client only really uses 3-4KB for the SDP but this gives some headroom.